### PR TITLE
Fix empty preload tags

### DIFF
--- a/src/Vite.php
+++ b/src/Vite.php
@@ -360,7 +360,7 @@ class Vite implements Stringable
             ? array_merge($attributes, ['integrity' => $chunk[$this->integrity] ?? false])
             : $attributes;
 
-        $attributes = array_merge($this->attributesResolver('preloadTagAttributes', $src, $url, $chunk, $manifest));
+        $attributes = array_merge($attributes, $this->attributesResolver('preloadTagAttributes', $src, $url, $chunk, $manifest));
 
         return $attributes;
     }


### PR DESCRIPTION
Currently, preload tags seem to come out as empty `<link>` tags. This should hopefully fix that :)